### PR TITLE
Restart Wallet service on crash

### DIFF
--- a/src/wallet/wallet.worker.ts
+++ b/src/wallet/wallet.worker.ts
@@ -235,7 +235,7 @@ class WalletWorker {
             } catch (error) {
                 this.logger.warn({
                     message: "Wallet crashed. Restarting wallet. Queue is maintained.",
-                    error,
+                    error: tryErrorToString(error),
                 });
             }
         }

--- a/src/wallet/wallet.worker.ts
+++ b/src/wallet/wallet.worker.ts
@@ -228,6 +228,26 @@ class WalletWorker {
         await this.transactionHelper.init();
         await this.confirmQueue.init();
 
+        // Keep main logic loop running, even if it crashes.
+        while (true) {
+            try {
+                await this.main();
+            } catch (error) {
+                this.logger.warn({
+                    message: "Wallet crashed. Restarting wallet. Queue is maintained.",
+                    error,
+                });
+            }
+        }
+    }
+
+    /**
+     * Main logic loop.
+     * @dev While the wallet shouldn't crash, it significantly impacts the relayer
+     * performance if it does. If another piece of software depends on the relayer
+     * then a wallet crash may be critical.
+     */
+    async main(): Promise<void> {
         while (true) {
             const newOrders = await this.processNewRequestsQueue();
 


### PR DESCRIPTION
If the wallet service crashes, it may create a stuck-queue. Since there is no explicit warning that the health of the wallet is bad, this may be deciving especially for people running Catalyst Underwriters who may think they are relaying swaps when they are not. 