### PR TITLE
feat: Allow 'startingBlock' to be a negative offset

### DIFF
--- a/src/collector/mock/mock.worker.ts
+++ b/src/collector/mock/mock.worker.ts
@@ -147,9 +147,18 @@ class MockCollectorWorker {
             // Do not initialize 'fromBlock' whilst 'currentStatus' is null, even if
             // 'startingBlock' is specified.
             if (this.currentStatus != null) {
-                fromBlock = (
-                    this.config.startingBlock ?? this.currentStatus.blockNumber
-                );
+                if (this.config.startingBlock != null) {
+                    if (this.config.startingBlock < 0) {
+                        fromBlock = this.currentStatus.blockNumber + this.config.startingBlock;
+                        if (fromBlock < 0) {
+                            throw new Error(`Invalid 'startingBlock': negative offset is larger than the current block number.`)
+                        }
+                    } else {
+                        fromBlock = this.config.startingBlock;
+                    }
+                } else {
+                    fromBlock = this.currentStatus.blockNumber;
+                }
             }
 
             await wait(this.config.processingInterval);

--- a/src/collector/polymer/polymer.worker.ts
+++ b/src/collector/polymer/polymer.worker.ts
@@ -110,9 +110,18 @@ class PolymerCollectorSnifferWorker {
             // Do not initialize 'fromBlock' whilst 'currentStatus' is null, even if
             // 'startingBlock' is specified.
             if (this.currentStatus != null) {
-                fromBlock = (
-                    this.config.startingBlock ?? this.currentStatus.blockNumber
-                );
+                if (this.config.startingBlock != null) {
+                    if (this.config.startingBlock < 0) {
+                        fromBlock = this.currentStatus.blockNumber + this.config.startingBlock;
+                        if (fromBlock < 0) {
+                            throw new Error(`Invalid 'startingBlock': negative offset is larger than the current block number.`)
+                        }
+                    } else {
+                        fromBlock = this.config.startingBlock;
+                    }
+                } else {
+                    fromBlock = this.currentStatus.blockNumber;
+                }
             }
 
             await wait(this.config.processingInterval);

--- a/src/collector/wormhole/wormhole-message-sniffer.worker.ts
+++ b/src/collector/wormhole/wormhole-message-sniffer.worker.ts
@@ -132,9 +132,18 @@ class WormholeMessageSnifferWorker {
             // Do not initialize 'fromBlock' whilst 'currentStatus' is null, even if
             // 'startingBlock' is specified.
             if (this.currentStatus != null) {
-                fromBlock = (
-                    this.config.startingBlock ?? this.currentStatus.blockNumber
-                );
+                if (this.config.startingBlock != null) {
+                    if (this.config.startingBlock < 0) {
+                        fromBlock = this.currentStatus.blockNumber + this.config.startingBlock;
+                        if (fromBlock < 0) {
+                            throw new Error(`Invalid 'startingBlock': negative offset is larger than the current block number.`)
+                        }
+                    } else {
+                        fromBlock = this.config.startingBlock;
+                    }
+                } else {
+                    fromBlock = this.currentStatus.blockNumber;
+                }
             }
 
             await wait(this.config.processingInterval);

--- a/src/config/config.schema.ts
+++ b/src/config/config.schema.ts
@@ -13,6 +13,12 @@ const POSITIVE_NUMBER_SCHEMA = {
     minimum: 0,
 }
 
+const INTEGER_SCHEMA = {
+    $id: "integer-schema",
+    type: "number",
+    multipleOf: 1,
+}
+
 const POSITIVE_NON_ZERO_INTEGER_SCHEMA = {
     $id: "positive-non-zero-integer-schema",
     type: "number",
@@ -212,7 +218,7 @@ const CHAINS_SCHEMA = {
             rpc: { $ref: "non-empty-string-schema" },
             resolver: { $ref: "non-empty-string-schema" },
 
-            startingBlock: { $ref: "positive-number-schema" },
+            startingBlock: { $ref: "integer-schema" },
             stoppingBlock: { $ref: "positive-number-schema" },
 
             monitor: { $ref: "monitor-schema" },
@@ -229,6 +235,7 @@ const CHAINS_SCHEMA = {
 export function getConfigValidator(): AnyValidateFunction<unknown> {
     const ajv = new Ajv({ strict: true });
     ajv.addSchema(POSITIVE_NUMBER_SCHEMA);
+    ajv.addSchema(INTEGER_SCHEMA);
     ajv.addSchema(POSITIVE_NON_ZERO_INTEGER_SCHEMA);
     ajv.addSchema(NON_EMPTY_STRING_SCHEMA);
     ajv.addSchema(ADDRESS_FIELD_SCHEMA);

--- a/src/getter/getter.worker.ts
+++ b/src/getter/getter.worker.ts
@@ -109,9 +109,18 @@ class GetterWorker {
             // Do not initialize 'fromBlock' whilst 'currentStatus' is null, even if
             // 'startingBlock' is specified.
             if (this.currentStatus != null) {
-                fromBlock = (
-                    this.config.startingBlock ?? this.currentStatus.blockNumber
-                );
+                if (this.config.startingBlock != null) {
+                    if (this.config.startingBlock < 0) {
+                        fromBlock = this.currentStatus.blockNumber + this.config.startingBlock;
+                        if (fromBlock < 0) {
+                            throw new Error(`Invalid 'startingBlock': negative offset is larger than the current block number.`)
+                        }
+                    } else {
+                        fromBlock = this.config.startingBlock;
+                    }
+                } else {
+                    fromBlock = this.currentStatus.blockNumber;
+                }
             }
 
             await wait(this.config.processingInterval);


### PR DESCRIPTION
Allow the `startingBlock` configuration to be a negative offset. This is useful to make the Relayer always recover the last `n` blocks upon starting.